### PR TITLE
Add Notes History page with filtering and pagination

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,65 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  fmt-check:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Show formatting differences if any
+        if: failure()
+        run: cargo fmt --all && git diff
+
+  test:
+    name: Run server tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run tests and capture output
+        id: test
+        run: |
+          cargo test --features server 2>&1 | tee test-output.txt
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "TESTS_FAILED=true" >> $GITHUB_OUTPUT
+          else
+            echo "TESTS_FAILED=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+      - name: Upload test output as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-output
+          path: test-output.txt
+          retention-days: 7
+      - name: Fail if tests failed
+        run: exit 1
+        if: steps.test.outputs.TESTS_FAILED == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "dioxus-primitives",
  "libsql",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ dioxus-primitives = { git = "https://github.com/DioxusLabs/components", version 
 libsql = { version = "0.9.29", optional = true }
 tokio = { version = "1.49.0", features = ["sync", "rt-multi-thread", "net"], optional = true }
 serde = "1.0.228"
+serde_json = "1.0.133"
 tracing = "0.1.44"
 base64 = {version = "0.22.1", optional = true}
 axum-prometheus = {version = "0.10.0", optional = true}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
 pub mod history_details_query;
 pub mod history_query;
 pub mod kids;
+pub mod notes_history_query;
 pub mod turso;
 
 #[cfg(all(test, feature = "server"))]
@@ -22,5 +23,12 @@ pub mod constants {
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(50)
+    });
+
+    pub const MAX_NOTES_HISTORY_PAGE_SIZE: LazyLock<u8> = LazyLock::new(|| {
+        env::var("HD_MAX_NOTES_HISTORY_PAGE_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(20)
     });
 }

--- a/src/backend/notes_history_query.rs
+++ b/src/backend/notes_history_query.rs
@@ -1,0 +1,370 @@
+#[cfg(feature = "server")]
+use dioxus::server::ServerFnError;
+
+#[cfg(feature = "server")]
+use base64::{engine::general_purpose::URL_SAFE, Engine as _};
+
+#[cfg(feature = "server")]
+use crate::{
+    backend::constants::MAX_NOTES_HISTORY_PAGE_SIZE,
+    models::{NoteHistory, NoteHistoryResponse},
+};
+
+#[cfg(feature = "server")]
+#[derive(Debug, serde::Deserialize)]
+struct NumberedNoteRow {
+    id: i64,
+    kid_id: u32,
+    kid_name: String,
+    quantity: i32,
+    created_at: String,
+    row_num: u32,
+    total_count: u32,
+}
+
+#[cfg(feature = "server")]
+impl NumberedNoteRow {
+    fn to_note_history(self) -> NoteHistory {
+        NoteHistory {
+            id: self.id,
+            kid_id: self.kid_id,
+            kid_name: self.kid_name,
+            quantity: self.quantity,
+            created_at: self.created_at,
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+pub struct NotesHistoryQuery {
+    kid_id: Option<u32>,
+    date_from: Option<String>,
+    date_to: Option<String>,
+    cursor: Option<String>,
+    page_size: u8,
+    sort_by: String,
+    sort_order: String,
+}
+
+#[cfg(feature = "server")]
+impl NotesHistoryQuery {
+    pub fn new(
+        kid_id: Option<u32>,
+        date_from: Option<String>,
+        date_to: Option<String>,
+        cursor: Option<String>,
+        page_size: u8,
+        sort_by: Option<String>,
+        sort_order: Option<String>,
+    ) -> Self {
+        let final_page_size = std::cmp::min(page_size, *MAX_NOTES_HISTORY_PAGE_SIZE);
+        if final_page_size != page_size {
+            tracing::warn!(
+                "Using default page size. Request {} exceeded system max {}",
+                page_size,
+                *MAX_NOTES_HISTORY_PAGE_SIZE
+            );
+        }
+
+        let sort_by = sort_by.unwrap_or_else(|| "created_at".to_string());
+        let sort_order = sort_order.unwrap_or_else(|| "desc".to_string());
+
+        Self {
+            kid_id,
+            date_from,
+            date_to,
+            cursor,
+            page_size: final_page_size,
+            sort_by,
+            sort_order,
+        }
+    }
+
+    fn get_sort_clause(&self) -> String {
+        let sort_column = match self.sort_by.as_str() {
+            "kid_name" => "kids.name",
+            "created_at" | _ => "notes.created_at",
+        };
+        let sort_dir = if self.sort_order == "asc" { "ASC" } else { "DESC" };
+        format!("ORDER BY {} {}", sort_column, sort_dir)
+    }
+
+    pub async fn execute(&self) -> Result<NoteHistoryResponse, ServerFnError> {
+        use crate::backend::turso::get_db;
+
+        let conn = get_db().await;
+        self.execute_with_db(conn).await
+    }
+
+    pub async fn execute_with_db(
+        &self,
+        conn: &'static libsql::Connection,
+    ) -> Result<NoteHistoryResponse, ServerFnError> {
+        let (mut notes, total_count) = self.fetch_notes(conn).await?;
+
+        if notes.is_empty() {
+            return Ok(NoteHistoryResponse {
+                notes: vec![],
+                cursor: None,
+                total_count: 0,
+                current_page: 1,
+                total_pages: 0,
+            });
+        }
+
+        let current_page = (notes[0].row_num - 1) / self.page_size as u32 + 1;
+        let total_pages = (total_count + self.page_size as u32 - 1) / self.page_size as u32;
+
+        let next_cursor = self.extract_next_cursor(&mut notes);
+        let note_history: Vec<NoteHistory> =
+            notes.into_iter().map(|r| r.to_note_history()).collect();
+
+        Ok(NoteHistoryResponse {
+            notes: note_history,
+            cursor: next_cursor,
+            total_count,
+            current_page,
+            total_pages,
+        })
+    }
+
+    /// Extracts the next cursor from the notes list if there are more items than the page size.
+    fn extract_next_cursor(&self, notes: &mut Vec<NumberedNoteRow>) -> Option<String> {
+        if notes.len() > self.page_size as usize {
+            // Discard the extra "peek" item
+            notes.pop();
+            // Cursor encodes the row_num of the last item in the current page
+            let last_in_page = notes.last().unwrap();
+            let cursor_str = format!(
+                "{}|{}|{}",
+                last_in_page.row_num, self.sort_by, self.sort_order
+            );
+            Some(URL_SAFE.encode(cursor_str.as_bytes()))
+        } else {
+            None
+        }
+    }
+
+    /// Fetches notes with filtering, sorting, and cursor-based pagination.
+    async fn fetch_notes(
+        &self,
+        conn: &'static libsql::Connection,
+    ) -> Result<(Vec<NumberedNoteRow>, u32), ServerFnError> {
+        let sort_clause = self.get_sort_clause();
+
+        let query = format!(
+            r#"
+            WITH all_notes AS (
+                SELECT
+                    notes.id,
+                    notes.kid_id,
+                    kids.name as kid_name,
+                    notes.quantity,
+                    notes.created_at,
+                    ROW_NUMBER() OVER ({sort_clause}) as row_num
+                FROM notes
+                JOIN kids ON notes.kid_id = kids.id
+                WHERE 1=1
+                    AND (:kid_id IS NULL OR notes.kid_id = :kid_id)
+                    AND (:date_from IS NULL OR notes.created_at >= :date_from)
+                    AND (:date_to IS NULL OR notes.created_at <= :date_to)
+            ),
+            total_counts AS (
+                SELECT COUNT(*) as total_count FROM all_notes
+            )
+            SELECT
+                n.id,
+                n.kid_id,
+                n.kid_name,
+                n.quantity,
+                n.created_at,
+                n.row_num,
+                t.total_count
+            FROM all_notes n
+            CROSS JOIN total_counts t
+            WHERE n.row_num > COALESCE(:cursor_row_num, 0)
+            {sort_clause}
+            LIMIT :limit
+            "#
+        );
+
+        tracing::debug!("SQL fetch_notes: {}", query);
+
+        let cursor_row_num = match &self.cursor {
+            Some(c) => {
+                let decoded = URL_SAFE
+                    .decode(c)
+                    .map_err(|e| ServerFnError::new(format!("Failed to decode cursor: {}", e)))?;
+                let cursor_str = String::from_utf8(decoded)
+                    .map_err(|e| ServerFnError::new(format!("Invalid UTF-8 in cursor: {}", e)))?;
+                let parts: Vec<&str> = cursor_str.split('|').collect();
+                if parts.len() >= 1 {
+                    parts[0]
+                        .parse::<u32>()
+                        .map_err(|e| ServerFnError::new(format!("Invalid cursor row_num: {}", e)))?
+                } else {
+                    0
+                }
+            }
+            None => 0,
+        };
+
+        let date_from = self.date_from.clone().unwrap_or_default();
+        let date_to = self.date_to.clone().unwrap_or_default();
+
+        let stm = conn
+            .prepare(&query)
+            .await
+            .map_err(|e| ServerFnError::new(e.to_string()))?;
+
+        let kid_id_param = self.kid_id.map(|id| id as i64);
+        let date_from_param = if date_from.is_empty() { None } else { Some(date_from) };
+        let date_to_param = if date_to.is_empty() { None } else { Some(date_to) };
+
+        let mut rows = stm
+            .query(libsql::named_params! {
+                ":limit": self.page_size + 1,
+                ":kid_id": kid_id_param,
+                ":date_from": date_from_param,
+                ":date_to": date_to_param,
+                ":cursor_row_num": cursor_row_num,
+            })
+            .await
+            .map_err(|e| ServerFnError::new(e.to_string()))?;
+
+        let mut numbered_notes: Vec<NumberedNoteRow> = Vec::new();
+        let mut total_count = 0u32;
+
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| ServerFnError::new(e.to_string()))?
+        {
+            let row_data = libsql::de::from_row::<NumberedNoteRow>(&row)
+                .map_err(|e| ServerFnError::new(e.to_string()))?;
+
+            if numbered_notes.is_empty() {
+                total_count = row_data.total_count;
+            }
+
+            numbered_notes.push(row_data);
+        }
+
+        Ok((numbered_notes, total_count))
+    }
+}
+
+// ============================================
+// TESTS
+// ============================================
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::test_db::setup_test_db;
+
+    #[test]
+    fn test_new_creates_query_with_defaults() {
+        let query = NotesHistoryQuery::new(None, None, None, None, 10, None, None);
+
+        assert!(query.kid_id.is_none());
+        assert!(query.date_from.is_none());
+        assert!(query.date_to.is_none());
+        assert!(query.cursor.is_none());
+        assert_eq!(query.page_size, 10);
+        assert_eq!(query.sort_by, "created_at");
+        assert_eq!(query.sort_order, "desc");
+    }
+
+    #[test]
+    fn test_new_with_all_params() {
+        let query = NotesHistoryQuery::new(
+            Some(1),
+            Some("2026-01-01".to_string()),
+            Some("2026-12-31".to_string()),
+            None,
+            20,
+            Some("kid_name".to_string()),
+            Some("asc".to_string()),
+        );
+
+        assert_eq!(query.kid_id, Some(1));
+        assert_eq!(query.date_from, Some("2026-01-01".to_string()));
+        assert_eq!(query.date_to, Some("2026-12-31".to_string()));
+        assert_eq!(query.page_size, 20);
+        assert_eq!(query.sort_by, "kid_name");
+        assert_eq!(query.sort_order, "asc");
+    }
+
+    #[test]
+    fn test_get_sort_clause_created_at_desc() {
+        let query = NotesHistoryQuery::new(None, None, None, None, 10, None, None);
+        let clause = query.get_sort_clause();
+
+        assert!(clause.contains("notes.created_at"));
+        assert!(clause.contains("DESC"));
+    }
+
+    #[test]
+    fn test_get_sort_clause_kid_name_asc() {
+        let query =
+            NotesHistoryQuery::new(None, None, None, None, 10, Some("kid_name".to_string()), Some("asc".to_string()));
+        let clause = query.get_sort_clause();
+
+        assert!(clause.contains("kids.name"));
+        assert!(clause.contains("ASC"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_returns_empty_for_no_data() {
+        let db = setup_test_db().await;
+        let db_static = Box::leak(Box::new(db));
+
+        let query = NotesHistoryQuery::new(Some(999), None, None, None, 10, None, None);
+        let result = query.execute_with_db(db_static).await.unwrap();
+
+        assert_eq!(result.notes.len(), 0);
+        assert_eq!(result.total_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_execute_returns_notes_with_kid_name() {
+        let db = setup_test_db().await;
+        let db_static = Box::leak(Box::new(db));
+
+        let query = NotesHistoryQuery::new(None, None, None, None, 10, None, None);
+        let result = query.execute_with_db(db_static).await.unwrap();
+
+        assert!(!result.notes.is_empty());
+        // All notes should have kid names
+        for note in &result.notes {
+            assert!(!note.kid_name.is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_filters_by_kid_id() {
+        let db = setup_test_db().await;
+        let db_static = Box::leak(Box::new(db));
+
+        let query = NotesHistoryQuery::new(Some(1), None, None, None, 10, None, None);
+        let result = query.execute_with_db(db_static).await.unwrap();
+
+        for note in &result.notes {
+            assert_eq!(note.kid_id, 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_paginates_correctly() {
+        let db = setup_test_db().await;
+        let db_static = Box::leak(Box::new(db));
+
+        let query = NotesHistoryQuery::new(None, None, None, None, 5, None, None);
+        let result = query.execute_with_db(db_static).await.unwrap();
+
+        assert!(result.notes.len() <= 5);
+        assert!(result.total_pages >= 1);
+    }
+}

--- a/src/backend/notes_history_query.rs
+++ b/src/backend/notes_history_query.rs
@@ -90,7 +90,10 @@ impl NotesHistoryQuery {
                     };
                 }
                 Err(e) => {
-                    tracing::warn!("Failed to decode cursor, falling back to filter params: {}", e);
+                    tracing::warn!(
+                        "Failed to decode cursor, falling back to filter params: {}",
+                        e
+                    );
                 }
             }
         }
@@ -148,7 +151,11 @@ impl NotesHistoryQuery {
             "kid_name" => "kids.name",
             "created_at" | _ => "notes.created_at",
         };
-        let sort_dir = if self.sort_order == "asc" { "ASC" } else { "DESC" };
+        let sort_dir = if self.sort_order == "asc" {
+            "ASC"
+        } else {
+            "DESC"
+        };
         format!("ORDER BY {} {}", sort_column, sort_dir)
     }
 
@@ -157,7 +164,11 @@ impl NotesHistoryQuery {
             "kid_name" => "n.kid_name",
             "created_at" | _ => "n.created_at",
         };
-        let sort_dir = if self.sort_order == "asc" { "ASC" } else { "DESC" };
+        let sort_dir = if self.sort_order == "asc" {
+            "ASC"
+        } else {
+            "DESC"
+        };
         format!("ORDER BY {} {}", sort_column, sort_dir)
     }
 
@@ -268,8 +279,16 @@ impl NotesHistoryQuery {
             .map_err(|e| ServerFnError::new(e.to_string()))?;
 
         let kid_id_param = self.kid_id.map(|id| id as i64);
-        let date_from_param = if date_from.is_empty() { None } else { Some(date_from) };
-        let date_to_param = if date_to.is_empty() { None } else { Some(date_to) };
+        let date_from_param = if date_from.is_empty() {
+            None
+        } else {
+            Some(date_from)
+        };
+        let date_to_param = if date_to.is_empty() {
+            None
+        } else {
+            Some(date_to)
+        };
 
         let mut rows = stm
             .query(libsql::named_params! {
@@ -421,12 +440,12 @@ mod tests {
             sort_order: "asc".to_string(),
             page_size: 25,
         };
-        
+
         let json = serde_json::to_string(&cursor).unwrap();
         let encoded = URL_SAFE.encode(json.as_bytes());
-        
+
         let decoded = NotesHistoryQuery::decode_cursor(&encoded).unwrap();
-        
+
         assert_eq!(decoded.row_num, 42);
         assert_eq!(decoded.kid_id, Some(3));
         assert_eq!(decoded.date_from, Some("2026-01-15".to_string()));
@@ -526,7 +545,7 @@ mod tests {
             // Use cursor with DIFFERENT filter params - they should be ignored
             let filter2 = NotesHistoryFilter {
                 kid_id: Some(999), // This should be ignored
-                page_size: 100,   // This should be ignored
+                page_size: 100,    // This should be ignored
                 cursor: Some(cursor),
                 ..Default::default()
             };

--- a/src/backend/notes_history_query.rs
+++ b/src/backend/notes_history_query.rs
@@ -35,7 +35,20 @@ impl NumberedNoteRow {
     }
 }
 
-/// Filter parameters for notes history queries
+/// Cursor for notes history pagination - carries all context needed for the next page.
+/// When provided, filter params are ignored and all values come from the cursor.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct NotesHistoryCursor {
+    pub row_num: u32,
+    pub kid_id: Option<u32>,
+    pub date_from: Option<String>,
+    pub date_to: Option<String>,
+    pub sort_by: String,
+    pub sort_order: String,
+    pub page_size: u8,
+}
+
+/// Filter parameters for notes history queries (used only for the first page)
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct NotesHistoryFilter {
     pub kid_id: Option<u32>,
@@ -52,7 +65,7 @@ pub struct NotesHistoryQuery {
     kid_id: Option<u32>,
     date_from: Option<String>,
     date_to: Option<String>,
-    cursor: Option<String>,
+    cursor_row_num: u32,
     page_size: u8,
     sort_by: String,
     sort_order: String,
@@ -61,8 +74,30 @@ pub struct NotesHistoryQuery {
 #[cfg(feature = "server")]
 impl NotesHistoryQuery {
     pub fn new(filter: NotesHistoryFilter) -> Self {
+        // If cursor is provided, decode it and use ALL values from cursor (ignore filter params)
+        // If no cursor, use the filter params for the first page
+        if let Some(cursor_str) = &filter.cursor {
+            match Self::decode_cursor(cursor_str) {
+                Ok(cursor) => {
+                    return Self {
+                        kid_id: cursor.kid_id,
+                        date_from: cursor.date_from,
+                        date_to: cursor.date_to,
+                        cursor_row_num: cursor.row_num,
+                        page_size: cursor.page_size,
+                        sort_by: cursor.sort_by,
+                        sort_order: cursor.sort_order,
+                    };
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to decode cursor, falling back to filter params: {}", e);
+                }
+            }
+        }
+
+        // No cursor (or failed decode) - use filter params for first page
         let final_page_size = std::cmp::min(filter.page_size, *MAX_NOTES_HISTORY_PAGE_SIZE);
-        if final_page_size != filter.page_size {
+        if final_page_size != filter.page_size && filter.page_size > 0 {
             tracing::warn!(
                 "Using default page size. Request {} exceeded system max {}",
                 filter.page_size,
@@ -77,11 +112,35 @@ impl NotesHistoryQuery {
             kid_id: filter.kid_id,
             date_from: filter.date_from,
             date_to: filter.date_to,
-            cursor: filter.cursor,
+            cursor_row_num: 0,
             page_size: final_page_size,
             sort_by,
             sort_order,
         }
+    }
+
+    fn decode_cursor(cursor_str: &str) -> Result<NotesHistoryCursor, ServerFnError> {
+        let decoded = URL_SAFE
+            .decode(cursor_str.as_bytes())
+            .map_err(|e| ServerFnError::new(format!("Failed to decode cursor: {}", e)))?;
+        let json_str = String::from_utf8(decoded)
+            .map_err(|e| ServerFnError::new(format!("Invalid UTF-8 in cursor: {}", e)))?;
+        serde_json::from_str(&json_str)
+            .map_err(|e| ServerFnError::new(format!("Invalid cursor JSON: {}", e)))?
+    }
+
+    fn encode_cursor(&self, row_num: u32) -> String {
+        let cursor = NotesHistoryCursor {
+            row_num,
+            kid_id: self.kid_id,
+            date_from: self.date_from.clone(),
+            date_to: self.date_to.clone(),
+            sort_by: self.sort_by.clone(),
+            sort_order: self.sort_order.clone(),
+            page_size: self.page_size,
+        };
+        let json = serde_json::to_string(&cursor).unwrap();
+        URL_SAFE.encode(json.as_bytes())
     }
 
     fn get_sort_clause(&self) -> String {
@@ -137,13 +196,9 @@ impl NotesHistoryQuery {
         if notes.len() > self.page_size as usize {
             // Discard the extra "peek" item
             notes.pop();
-            // Cursor encodes the row_num of the last item in the current page
+            // Cursor encodes all context needed for the next page
             let last_in_page = notes.last().unwrap();
-            let cursor_str = format!(
-                "{}|{}|{}",
-                last_in_page.row_num, self.sort_by, self.sort_order
-            );
-            Some(URL_SAFE.encode(cursor_str.as_bytes()))
+            Some(self.encode_cursor(last_in_page.row_num))
         } else {
             None
         }
@@ -186,32 +241,13 @@ impl NotesHistoryQuery {
                 t.total_count
             FROM all_notes n
             CROSS JOIN total_counts t
-            WHERE n.row_num > COALESCE(:cursor_row_num, 0)
+            WHERE n.row_num > :cursor_row_num
             {sort_clause}
             LIMIT :limit
             "#
         );
 
         tracing::debug!("SQL fetch_notes: {}", query);
-
-        let cursor_row_num = match &self.cursor {
-            Some(c) => {
-                let decoded = URL_SAFE
-                    .decode(c)
-                    .map_err(|e| ServerFnError::new(format!("Failed to decode cursor: {}", e)))?;
-                let cursor_str = String::from_utf8(decoded)
-                    .map_err(|e| ServerFnError::new(format!("Invalid UTF-8 in cursor: {}", e)))?;
-                let parts: Vec<&str> = cursor_str.split('|').collect();
-                if parts.len() >= 1 {
-                    parts[0]
-                        .parse::<u32>()
-                        .map_err(|e| ServerFnError::new(format!("Invalid cursor row_num: {}", e)))?
-                } else {
-                    0
-                }
-            }
-            None => 0,
-        };
 
         let date_from = self.date_from.clone().unwrap_or_default();
         let date_to = self.date_to.clone().unwrap_or_default();
@@ -231,7 +267,7 @@ impl NotesHistoryQuery {
                 ":kid_id": kid_id_param,
                 ":date_from": date_from_param,
                 ":date_to": date_to_param,
-                ":cursor_row_num": cursor_row_num,
+                ":cursor_row_num": self.cursor_row_num,
             })
             .await
             .map_err(|e| ServerFnError::new(e.to_string()))?;
@@ -275,14 +311,14 @@ mod tests {
         assert!(query.kid_id.is_none());
         assert!(query.date_from.is_none());
         assert!(query.date_to.is_none());
-        assert!(query.cursor.is_none());
+        assert_eq!(query.cursor_row_num, 0);
         assert_eq!(query.page_size, 0); // default u8 is 0
         assert_eq!(query.sort_by, "created_at");
         assert_eq!(query.sort_order, "desc");
     }
 
     #[test]
-    fn test_new_with_all_params() {
+    fn test_new_with_all_filter_params() {
         let filter = NotesHistoryFilter {
             kid_id: Some(1),
             date_from: Some("2026-01-01".to_string()),
@@ -297,7 +333,45 @@ mod tests {
         assert_eq!(query.kid_id, Some(1));
         assert_eq!(query.date_from, Some("2026-01-01".to_string()));
         assert_eq!(query.date_to, Some("2026-12-31".to_string()));
+        assert_eq!(query.cursor_row_num, 0);
         assert_eq!(query.page_size, 20);
+        assert_eq!(query.sort_by, "kid_name");
+        assert_eq!(query.sort_order, "asc");
+    }
+
+    #[test]
+    fn test_new_uses_cursor_over_filter_params() {
+        // Create a cursor with different values than the filter
+        let cursor = NotesHistoryCursor {
+            row_num: 50,
+            kid_id: Some(2),
+            date_from: Some("2025-01-01".to_string()),
+            date_to: Some("2025-12-31".to_string()),
+            sort_by: "kid_name".to_string(),
+            sort_order: "asc".to_string(),
+            page_size: 15,
+        };
+        let json = serde_json::to_string(&cursor).unwrap();
+        let cursor_str = URL_SAFE.encode(json.as_bytes());
+
+        // Filter has different values, but they should be ignored
+        let filter = NotesHistoryFilter {
+            kid_id: Some(1),
+            date_from: Some("2026-01-01".to_string()),
+            date_to: Some("2026-12-31".to_string()),
+            cursor: Some(cursor_str),
+            page_size: 20,
+            sort_by: Some("created_at".to_string()),
+            sort_order: Some("desc".to_string()),
+        };
+        let query = NotesHistoryQuery::new(filter);
+
+        // Values should come from cursor, not filter
+        assert_eq!(query.kid_id, Some(2));
+        assert_eq!(query.date_from, Some("2025-01-01".to_string()));
+        assert_eq!(query.date_to, Some("2025-12-31".to_string()));
+        assert_eq!(query.cursor_row_num, 50);
+        assert_eq!(query.page_size, 15);
         assert_eq!(query.sort_by, "kid_name");
         assert_eq!(query.sort_order, "asc");
     }
@@ -324,6 +398,32 @@ mod tests {
 
         assert!(clause.contains("kids.name"));
         assert!(clause.contains("ASC"));
+    }
+
+    #[test]
+    fn test_encode_decode_cursor_roundtrip() {
+        let cursor = NotesHistoryCursor {
+            row_num: 42,
+            kid_id: Some(3),
+            date_from: Some("2026-01-15".to_string()),
+            date_to: Some("2026-02-20".to_string()),
+            sort_by: "kid_name".to_string(),
+            sort_order: "asc".to_string(),
+            page_size: 25,
+        };
+        
+        let json = serde_json::to_string(&cursor).unwrap();
+        let encoded = URL_SAFE.encode(json.as_bytes());
+        
+        let decoded = NotesHistoryQuery::decode_cursor(&encoded).unwrap();
+        
+        assert_eq!(decoded.row_num, 42);
+        assert_eq!(decoded.kid_id, Some(3));
+        assert_eq!(decoded.date_from, Some("2026-01-15".to_string()));
+        assert_eq!(decoded.date_to, Some("2026-02-20".to_string()));
+        assert_eq!(decoded.sort_by, "kid_name");
+        assert_eq!(decoded.sort_order, "asc");
+        assert_eq!(decoded.page_size, 25);
     }
 
     #[tokio::test]
@@ -394,6 +494,40 @@ mod tests {
 
         assert!(result.notes.len() <= 5);
         assert!(result.total_pages >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_carries_filter_context() {
+        let db = setup_test_db().await;
+        let db_static = Box::leak(Box::new(db));
+
+        // First page with filter
+        let filter = NotesHistoryFilter {
+            kid_id: Some(1),
+            page_size: 2,
+            sort_by: Some("created_at".to_string()),
+            sort_order: Some("desc".to_string()),
+            ..Default::default()
+        };
+        let query = NotesHistoryQuery::new(filter);
+        let result = query.execute_with_db(db_static).await.unwrap();
+
+        if let Some(cursor) = result.cursor {
+            // Use cursor with DIFFERENT filter params - they should be ignored
+            let filter2 = NotesHistoryFilter {
+                kid_id: Some(999), // This should be ignored
+                page_size: 999,    // This should be ignored
+                cursor: Some(cursor),
+                ..Default::default()
+            };
+            let query2 = NotesHistoryQuery::new(filter2);
+            let result2 = query2.execute_with_db(db_static).await.unwrap();
+
+            // Should still get kid_id=1 results because cursor carries the context
+            for note in &result2.notes {
+                assert_eq!(note.kid_id, 1);
+            }
+        }
     }
 
     async fn setup_test_db() -> libsql::Connection {

--- a/src/backend/notes_history_query.rs
+++ b/src/backend/notes_history_query.rs
@@ -35,6 +35,18 @@ impl NumberedNoteRow {
     }
 }
 
+/// Filter parameters for notes history queries
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct NotesHistoryFilter {
+    pub kid_id: Option<u32>,
+    pub date_from: Option<String>,
+    pub date_to: Option<String>,
+    pub cursor: Option<String>,
+    pub page_size: u8,
+    pub sort_by: Option<String>,
+    pub sort_order: Option<String>,
+}
+
 #[cfg(feature = "server")]
 pub struct NotesHistoryQuery {
     kid_id: Option<u32>,
@@ -48,32 +60,24 @@ pub struct NotesHistoryQuery {
 
 #[cfg(feature = "server")]
 impl NotesHistoryQuery {
-    pub fn new(
-        kid_id: Option<u32>,
-        date_from: Option<String>,
-        date_to: Option<String>,
-        cursor: Option<String>,
-        page_size: u8,
-        sort_by: Option<String>,
-        sort_order: Option<String>,
-    ) -> Self {
-        let final_page_size = std::cmp::min(page_size, *MAX_NOTES_HISTORY_PAGE_SIZE);
-        if final_page_size != page_size {
+    pub fn new(filter: NotesHistoryFilter) -> Self {
+        let final_page_size = std::cmp::min(filter.page_size, *MAX_NOTES_HISTORY_PAGE_SIZE);
+        if final_page_size != filter.page_size {
             tracing::warn!(
                 "Using default page size. Request {} exceeded system max {}",
-                page_size,
+                filter.page_size,
                 *MAX_NOTES_HISTORY_PAGE_SIZE
             );
         }
 
-        let sort_by = sort_by.unwrap_or_else(|| "created_at".to_string());
-        let sort_order = sort_order.unwrap_or_else(|| "desc".to_string());
+        let sort_by = filter.sort_by.unwrap_or_else(|| "created_at".to_string());
+        let sort_order = filter.sort_order.unwrap_or_else(|| "desc".to_string());
 
         Self {
-            kid_id,
-            date_from,
-            date_to,
-            cursor,
+            kid_id: filter.kid_id,
+            date_from: filter.date_from,
+            date_to: filter.date_to,
+            cursor: filter.cursor,
             page_size: final_page_size,
             sort_by,
             sort_order,
@@ -262,32 +266,33 @@ impl NotesHistoryQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::backend::test_db::setup_test_db;
 
     #[test]
     fn test_new_creates_query_with_defaults() {
-        let query = NotesHistoryQuery::new(None, None, None, None, 10, None, None);
+        let filter = NotesHistoryFilter::default();
+        let query = NotesHistoryQuery::new(filter);
 
         assert!(query.kid_id.is_none());
         assert!(query.date_from.is_none());
         assert!(query.date_to.is_none());
         assert!(query.cursor.is_none());
-        assert_eq!(query.page_size, 10);
+        assert_eq!(query.page_size, 0); // default u8 is 0
         assert_eq!(query.sort_by, "created_at");
         assert_eq!(query.sort_order, "desc");
     }
 
     #[test]
     fn test_new_with_all_params() {
-        let query = NotesHistoryQuery::new(
-            Some(1),
-            Some("2026-01-01".to_string()),
-            Some("2026-12-31".to_string()),
-            None,
-            20,
-            Some("kid_name".to_string()),
-            Some("asc".to_string()),
-        );
+        let filter = NotesHistoryFilter {
+            kid_id: Some(1),
+            date_from: Some("2026-01-01".to_string()),
+            date_to: Some("2026-12-31".to_string()),
+            cursor: None,
+            page_size: 20,
+            sort_by: Some("kid_name".to_string()),
+            sort_order: Some("asc".to_string()),
+        };
+        let query = NotesHistoryQuery::new(filter);
 
         assert_eq!(query.kid_id, Some(1));
         assert_eq!(query.date_from, Some("2026-01-01".to_string()));
@@ -299,7 +304,8 @@ mod tests {
 
     #[test]
     fn test_get_sort_clause_created_at_desc() {
-        let query = NotesHistoryQuery::new(None, None, None, None, 10, None, None);
+        let filter = NotesHistoryFilter::default();
+        let query = NotesHistoryQuery::new(filter);
         let clause = query.get_sort_clause();
 
         assert!(clause.contains("notes.created_at"));
@@ -308,8 +314,12 @@ mod tests {
 
     #[test]
     fn test_get_sort_clause_kid_name_asc() {
-        let query =
-            NotesHistoryQuery::new(None, None, None, None, 10, Some("kid_name".to_string()), Some("asc".to_string()));
+        let filter = NotesHistoryFilter {
+            sort_by: Some("kid_name".to_string()),
+            sort_order: Some("asc".to_string()),
+            ..Default::default()
+        };
+        let query = NotesHistoryQuery::new(filter);
         let clause = query.get_sort_clause();
 
         assert!(clause.contains("kids.name"));
@@ -321,7 +331,12 @@ mod tests {
         let db = setup_test_db().await;
         let db_static = Box::leak(Box::new(db));
 
-        let query = NotesHistoryQuery::new(Some(999), None, None, None, 10, None, None);
+        let filter = NotesHistoryFilter {
+            kid_id: Some(999),
+            page_size: 10,
+            ..Default::default()
+        };
+        let query = NotesHistoryQuery::new(filter);
         let result = query.execute_with_db(db_static).await.unwrap();
 
         assert_eq!(result.notes.len(), 0);
@@ -333,7 +348,11 @@ mod tests {
         let db = setup_test_db().await;
         let db_static = Box::leak(Box::new(db));
 
-        let query = NotesHistoryQuery::new(None, None, None, None, 10, None, None);
+        let filter = NotesHistoryFilter {
+            page_size: 10,
+            ..Default::default()
+        };
+        let query = NotesHistoryQuery::new(filter);
         let result = query.execute_with_db(db_static).await.unwrap();
 
         assert!(!result.notes.is_empty());
@@ -348,7 +367,12 @@ mod tests {
         let db = setup_test_db().await;
         let db_static = Box::leak(Box::new(db));
 
-        let query = NotesHistoryQuery::new(Some(1), None, None, None, 10, None, None);
+        let filter = NotesHistoryFilter {
+            kid_id: Some(1),
+            page_size: 10,
+            ..Default::default()
+        };
+        let query = NotesHistoryQuery::new(filter);
         let result = query.execute_with_db(db_static).await.unwrap();
 
         for note in &result.notes {
@@ -361,10 +385,18 @@ mod tests {
         let db = setup_test_db().await;
         let db_static = Box::leak(Box::new(db));
 
-        let query = NotesHistoryQuery::new(None, None, None, None, 5, None, None);
+        let filter = NotesHistoryFilter {
+            page_size: 5,
+            ..Default::default()
+        };
+        let query = NotesHistoryQuery::new(filter);
         let result = query.execute_with_db(db_static).await.unwrap();
 
         assert!(result.notes.len() <= 5);
         assert!(result.total_pages >= 1);
+    }
+
+    async fn setup_test_db() -> libsql::Connection {
+        crate::backend::test_db::setup_test_db().await
     }
 }

--- a/src/backend/notes_history_query.rs
+++ b/src/backend/notes_history_query.rs
@@ -125,8 +125,8 @@ impl NotesHistoryQuery {
             .map_err(|e| ServerFnError::new(format!("Failed to decode cursor: {}", e)))?;
         let json_str = String::from_utf8(decoded)
             .map_err(|e| ServerFnError::new(format!("Invalid UTF-8 in cursor: {}", e)))?;
-        serde_json::from_str(&json_str)
-            .map_err(|e| ServerFnError::new(format!("Invalid cursor JSON: {}", e)))?
+        Ok(serde_json::from_str::<NotesHistoryCursor>(&json_str)
+            .map_err(|e| ServerFnError::new(format!("Invalid cursor JSON: {}", e)))?)
     }
 
     fn encode_cursor(&self, row_num: u32) -> String {
@@ -143,10 +143,19 @@ impl NotesHistoryQuery {
         URL_SAFE.encode(json.as_bytes())
     }
 
-    fn get_sort_clause(&self) -> String {
+    fn get_sort_clause_for_row_number(&self) -> String {
         let sort_column = match self.sort_by.as_str() {
             "kid_name" => "kids.name",
             "created_at" | _ => "notes.created_at",
+        };
+        let sort_dir = if self.sort_order == "asc" { "ASC" } else { "DESC" };
+        format!("ORDER BY {} {}", sort_column, sort_dir)
+    }
+
+    fn get_sort_clause_for_outer_query(&self) -> String {
+        let sort_column = match self.sort_by.as_str() {
+            "kid_name" => "n.kid_name",
+            "created_at" | _ => "n.created_at",
         };
         let sort_dir = if self.sort_order == "asc" { "ASC" } else { "DESC" };
         format!("ORDER BY {} {}", sort_column, sort_dir)
@@ -209,7 +218,8 @@ impl NotesHistoryQuery {
         &self,
         conn: &'static libsql::Connection,
     ) -> Result<(Vec<NumberedNoteRow>, u32), ServerFnError> {
-        let sort_clause = self.get_sort_clause();
+        let sort_clause_inner = self.get_sort_clause_for_row_number();
+        let sort_clause_outer = self.get_sort_clause_for_outer_query();
 
         let query = format!(
             r#"
@@ -220,7 +230,7 @@ impl NotesHistoryQuery {
                     kids.name as kid_name,
                     notes.quantity,
                     notes.created_at,
-                    ROW_NUMBER() OVER ({sort_clause}) as row_num
+                    ROW_NUMBER() OVER ({sort_clause_inner}) as row_num
                 FROM notes
                 JOIN kids ON notes.kid_id = kids.id
                 WHERE 1=1
@@ -242,7 +252,7 @@ impl NotesHistoryQuery {
             FROM all_notes n
             CROSS JOIN total_counts t
             WHERE n.row_num > :cursor_row_num
-            {sort_clause}
+            {sort_clause_outer}
             LIMIT :limit
             "#
         );
@@ -380,7 +390,7 @@ mod tests {
     fn test_get_sort_clause_created_at_desc() {
         let filter = NotesHistoryFilter::default();
         let query = NotesHistoryQuery::new(filter);
-        let clause = query.get_sort_clause();
+        let clause = query.get_sort_clause_for_row_number();
 
         assert!(clause.contains("notes.created_at"));
         assert!(clause.contains("DESC"));
@@ -394,7 +404,7 @@ mod tests {
             ..Default::default()
         };
         let query = NotesHistoryQuery::new(filter);
-        let clause = query.get_sort_clause();
+        let clause = query.get_sort_clause_for_row_number();
 
         assert!(clause.contains("kids.name"));
         assert!(clause.contains("ASC"));
@@ -516,7 +526,7 @@ mod tests {
             // Use cursor with DIFFERENT filter params - they should be ignored
             let filter2 = NotesHistoryFilter {
                 kid_id: Some(999), // This should be ignored
-                page_size: 999,    // This should be ignored
+                page_size: 100,   // This should be ignored
                 cursor: Some(cursor),
                 ..Default::default()
             };

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -5,6 +5,7 @@ pub mod button;
 pub mod card;
 pub mod kid_card;
 pub mod kid_history;
+pub mod notes_history;
 pub mod popover;
 pub mod settings;
 pub mod toast;

--- a/src/components/notes_history/component.rs
+++ b/src/components/notes_history/component.rs
@@ -1,0 +1,372 @@
+use crate::backend::kids::list_kids;
+use crate::models::{KidSummary, NoteHistory};
+use crate::Route;
+use dioxus::prelude::*;
+use dioxus_primitives::toast::{consume_toast, ToastOptions};
+
+#[server]
+pub async fn get_notes_history(
+    kid_id: Option<u32>,
+    date_from: Option<String>,
+    date_to: Option<String>,
+    cursor: Option<String>,
+    page_size: u8,
+    sort_by: Option<String>,
+    sort_order: Option<String>,
+) -> Result<crate::models::NoteHistoryResponse, ServerFnError> {
+    use crate::backend::notes_history_query::NotesHistoryQuery;
+
+    let query = NotesHistoryQuery::new(kid_id, date_from, date_to, cursor, page_size, sort_by, sort_order);
+    query.execute().await
+}
+
+#[component]
+fn NoteRow(note: NoteHistory, show_kid: bool) -> Element {
+    let qty_label = if note.quantity > 0 {
+        format!("+{}", note.quantity)
+    } else {
+        format!("{}", note.quantity)
+    };
+    let qty_bg = if note.quantity >= 0 { "#dcfce7" } else { "#fee2e2" };
+    let qty_color = if note.quantity >= 0 { "#16a34a" } else { "#dc2626" };
+
+    rsx! {
+        tr {
+            class: "note-row",
+            style: "border-bottom: 1px solid #f3f4f6; transition: background-color 0.15s;",
+            
+            if show_kid {
+                td {
+                    style: "padding: 0.75rem 1rem; font-weight: 500; color: #374151;",
+                    "{note.kid_name}"
+                }
+            }
+            
+            td {
+                style: "padding: 0.75rem 1rem; color: #6b7280; font-size: 0.875rem;",
+                "{note.created_at}"
+            }
+            
+            td {
+                style: "padding: 0.75rem 1rem;",
+                span {
+                    style: "font-size: 0.875rem; font-weight: 600; padding: 0.25rem 0.75rem; border-radius: 0.375rem; background-color: {qty_bg}; color: {qty_color};",
+                    "{qty_label}"
+                }
+            }
+        }
+    }
+}
+
+const PAGE_SIZE: u8 = 20;
+
+#[component]
+pub fn NotesHistoryPage() -> Element {
+    let mut kids_resource = use_resource(list_kids);
+    
+    // Filter state
+    let mut selected_kid_id = use_signal(|| None::<u32>);
+    let mut date_from = use_signal(|| String::new());
+    let mut date_to = use_signal(|| String::new());
+    
+    // Sort state
+    let mut sort_by = use_signal(|| "created_at".to_string());
+    let mut sort_order = use_signal(|| "desc".to_string());
+    
+    // Pagination state
+    let mut current_page = use_signal(|| 1usize);
+    let mut total_pages = use_signal(|| 1usize);
+    let mut total_count = use_signal(|| 0u32);
+    let mut has_next = use_signal(|| false);
+    let mut cursor = use_signal(|| None::<String>);
+    let mut cursor_stack = use_signal(|| vec![None::<String>]);
+
+    // The notes resource - reactive to all filters and cursor
+    let notes = use_resource(move || {
+        get_notes_history(
+            selected_kid_id(),
+            if date_from().is_empty() { None } else { Some(date_from()) },
+            if date_to().is_empty() { None } else { Some(date_to()) },
+            cursor(),
+            PAGE_SIZE,
+            Some(sort_by()),
+            Some(sort_order()),
+        )
+    });
+
+    let toast = consume_toast();
+
+    use_effect(move || {
+        if let Some(Ok(response)) = notes.read().as_ref() {
+            total_pages.set(response.total_pages as usize);
+            total_count.set(response.total_count);
+            has_next.set(response.cursor.is_some());
+
+            if let Some(ref next_cursor) = response.cursor {
+                let cp = *current_page.peek();
+                cursor_stack.with_mut(|stack| {
+                    if stack.len() <= cp {
+                        stack.push(Some(next_cursor.clone()));
+                    }
+                });
+            }
+        } else if let Some(Err(e)) = notes.read().as_ref() {
+            toast.error(
+                format!("Failed to load history: {}", e),
+                ToastOptions::new(),
+            );
+        }
+    });
+
+    // Reset pagination when filters change
+    let apply_filters = move |_| {
+        current_page.set(1);
+        cursor.set(None);
+        cursor_stack.set(vec![None]);
+        notes.restart();
+    };
+
+    let toggle_sort = move |column: String| {
+        let current_column = sort_by();
+        if current_column == column {
+            // Toggle order
+            let new_order = if sort_order() == "desc" { "asc" } else { "desc" };
+            sort_order.set(new_order.to_string());
+        } else {
+            sort_by.set(column);
+            sort_order.set("desc".to_string());
+        }
+        // Reset pagination
+        current_page.set(1);
+        cursor.set(None);
+        cursor_stack.set(vec![None]);
+    };
+
+    rsx! {
+        style { "
+            .note-row:hover {{ background-color: #f9fafb; }}
+        " }
+
+        div { style: "max-width: 720px; margin: 0 auto;",
+
+            // ── Header ──
+            div { class: "mb-8 flex items-center gap-4",
+                Link {
+                    to: Route::SettingsView,
+                    style: "display: flex; align-items: center; justify-content: center; width: 2rem; height: 2rem; border-radius: 50%; color: #9ca3af; transition: all 0.15s;",
+                    svg {
+                        xmlns: "http://www.w3.org/2000/svg",
+                        fill: "none",
+                        view_box: "0 0 24 24",
+                        stroke_width: "2",
+                        stroke: "currentColor",
+                        class: "h-5 w-5",
+                        path {
+                            stroke_linecap: "round",
+                            stroke_linejoin: "round",
+                            d: "M15.75 19.5 8.25 12l7.5-7.5",
+                        }
+                    }
+                }
+                h1 { class: "text-2xl font-semibold text-gray-900", "Notes History" }
+            }
+
+            // ── Filters Section ──
+            div { style: "margin-bottom: 1.5rem; border-radius: 0.75rem; border: 1px solid #e5e7eb; background: white; box-shadow: 0 1px 2px rgba(0,0,0,0.05); overflow: hidden;",
+                div { style: "padding: 1.25rem;",
+                    h2 { class: "text-sm font-semibold text-gray-700 mb-3", "Filters" }
+                    
+                    div { style: "display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem;",
+                        // Kid filter
+                        div {
+                            label { class: "block text-xs font-medium text-gray-500 mb-1", "Kid" }
+                            match &*kids_resource.read() {
+                                Some(Ok(kids)) => rsx! {
+                                    select {
+                                        style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; font-size: 0.875rem;",
+                                        onchange: move |e: Event<FormData>| {
+                                            let val = e.value();
+                                            selected_kid_id.set(if val.is_empty() { None } else { val.parse().ok() });
+                                        },
+                                        option { value: "", "All Kids" }
+                                        for kid in kids.iter() {
+                                            option {
+                                                value: "{kid.id}",
+                                                selected: selected_kid_id() == Some(kid.id),
+                                                "{kid.name}"
+                                            }
+                                        }
+                                    }
+                                },
+                                _ => rsx! {
+                                    select {
+                                        style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: #f9fafb; font-size: 0.875rem;",
+                                        disabled: true,
+                                        option { "Loading..." }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Apply button
+                        div { style: "display: flex; align-items: flex-end;",
+                            button {
+                                style: "width: 100%; padding: 0.5rem 1rem; border-radius: 0.5rem; border: none; background: #3b82f6; color: white; font-size: 0.875rem; font-weight: 500; cursor: pointer; transition: background-color 0.15s;",
+                                onclick: apply_filters,
+                                "Apply Filters"
+                            }
+                        }
+                    }
+
+                    div { style: "display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;",
+                        // Date from
+                        div {
+                            label { class: "block text-xs font-medium text-gray-500 mb-1", "From Date" }
+                            input {
+                                r#type: "date",
+                                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; font-size: 0.875rem;",
+                                value: "{date_from}",
+                                oninput: move |e: Event<FormData>| date_from.set(e.value()),
+                            }
+                        }
+
+                        // Date to
+                        div {
+                            label { class: "block text-xs font-medium text-gray-500 mb-1", "To Date" }
+                            input {
+                                r#type: "date",
+                                style: "width: 100%; padding: 0.5rem 0.75rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; font-size: 0.875rem;",
+                                value: "{date_to}",
+                                oninput: move |e: Event<FormData>| date_to.set(e.value()),
+                            }
+                        }
+                    }
+                }
+            }
+
+            // ── Table Section ──
+            div { style: "border-radius: 0.75rem; border: 1px solid #e5e7eb; background: white; box-shadow: 0 1px 2px rgba(0,0,0,0.05); overflow: hidden;",
+
+                // ── Pagination Toolbar ──
+                if total_count() > 0 {
+                    div { style: "display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.75rem 1rem; border-bottom: 1px solid #e5e7eb; background: #f9fafb;",
+                        button {
+                            style: if current_page() == 1 { 
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: not-allowed; color: #d1d5db;" 
+                            } else { 
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: pointer; color: #374151;" 
+                            },
+                            disabled: current_page() == 1,
+                            onclick: move |_| {
+                                if current_page() > 1 {
+                                    let prev_page = current_page() - 1;
+                                    let prev_cursor = cursor_stack.read().get(prev_page - 1).cloned().flatten();
+                                    cursor.set(prev_cursor);
+                                    current_page.set(prev_page);
+                                }
+                            },
+                            "Previous"
+                        }
+
+                        span { style: "font-size: 0.875rem; color: #6b7280;",
+                            "Page {current_page()} of {total_pages()} ({total_count()} notes)"
+                        }
+
+                        button {
+                            style: if !has_next() { 
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: not-allowed; color: #d1d5db;" 
+                            } else { 
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: pointer; color: #374151;" 
+                            },
+                            disabled: !has_next(),
+                            onclick: move |_| {
+                                let next_cursor = cursor_stack.read().get(current_page()).cloned().flatten();
+                                cursor.set(next_cursor);
+                                current_page.set(current_page() + 1);
+                            },
+                            "Next"
+                        }
+                    }
+                }
+
+                // ── Table ──
+                table { style: "width: 100%; border-collapse: collapse;",
+                    thead {
+                        style: "background: #f9fafb;",
+                        tr {
+                            th {
+                                style: "padding: 0.75rem 1rem; text-align: left; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; cursor: pointer; user-select: none;",
+                                onclick: move |_| toggle_sort("kid_name".to_string()),
+                                span { "Kid " }
+                                if sort_by() == "kid_name" {
+                                    span { 
+                                        style: "margin-left: 0.25rem;",
+                                        if sort_order() == "asc" { "↑" } else { "↓" }
+                                    }
+                                }
+                            }
+                            th {
+                                style: "padding: 0.75rem 1rem; text-align: left; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; cursor: pointer; user-select: none;",
+                                onclick: move |_| toggle_sort("created_at".to_string()),
+                                span { "Date " }
+                                if sort_by() == "created_at" {
+                                    span { 
+                                        style: "margin-left: 0.25rem;",
+                                        if sort_order() == "asc" { "↑" } else { "↓" }
+                                    }
+                                }
+                            }
+                            th {
+                                style: "padding: 0.75rem 1rem; text-align: left; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;",
+                                "Quantity"
+                            }
+                        }
+                    }
+                    tbody {
+                        match &*notes.read() {
+                            None => rsx! {
+                                tr {
+                                    td {
+                                        colspan: 3,
+                                        style: "padding: 2rem; text-align: center; color: #9ca3af;",
+                                        "Loading..."
+                                    }
+                                }
+                            },
+                            Some(Ok(response)) if response.notes.is_empty() => rsx! {
+                                tr {
+                                    td {
+                                        colspan: 3,
+                                        style: "padding: 3rem; text-align: center;",
+                                        div {
+                                            style: "color: #9ca3af;",
+                                            p { style: "font-size: 1rem; font-weight: 500; margin-bottom: 0.25rem;", "No Notes Found" }
+                                            p { style: "font-size: 0.875rem;", "Try adjusting your filters." }
+                                        }
+                                    }
+                                }
+                            },
+                            Some(Ok(response)) => rsx! {
+                                for note in response.notes.iter() {
+                                    NoteRow {
+                                        note: note.clone(),
+                                        show_kid: true,
+                                    }
+                                }
+                            },
+                            Some(Err(_)) => rsx! {
+                                tr {
+                                    td {
+                                        colspan: 3,
+                                        style: "padding: 2rem; text-align: center; color: #ef4444;",
+                                        "Failed to load notes"
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/components/notes_history/component.rs
+++ b/src/components/notes_history/component.rs
@@ -1,4 +1,5 @@
 use crate::backend::kids::list_kids;
+use crate::backend::notes_history_query::NotesHistoryFilter;
 use crate::models::{KidSummary, NoteHistory};
 use crate::Route;
 use dioxus::prelude::*;
@@ -6,17 +7,11 @@ use dioxus_primitives::toast::{consume_toast, ToastOptions};
 
 #[server]
 pub async fn get_notes_history(
-    kid_id: Option<u32>,
-    date_from: Option<String>,
-    date_to: Option<String>,
-    cursor: Option<String>,
-    page_size: u8,
-    sort_by: Option<String>,
-    sort_order: Option<String>,
+    filter: NotesHistoryFilter,
 ) -> Result<crate::models::NoteHistoryResponse, ServerFnError> {
     use crate::backend::notes_history_query::NotesHistoryQuery;
 
-    let query = NotesHistoryQuery::new(kid_id, date_from, date_to, cursor, page_size, sort_by, sort_order);
+    let query = NotesHistoryQuery::new(filter);
     query.execute().await
 }
 
@@ -83,15 +78,15 @@ pub fn NotesHistoryPage() -> Element {
 
     // The notes resource - reactive to all filters and cursor
     let notes = use_resource(move || {
-        get_notes_history(
-            selected_kid_id(),
-            if date_from().is_empty() { None } else { Some(date_from()) },
-            if date_to().is_empty() { None } else { Some(date_to()) },
-            cursor(),
-            PAGE_SIZE,
-            Some(sort_by()),
-            Some(sort_order()),
-        )
+        get_notes_history(NotesHistoryFilter {
+            kid_id: selected_kid_id(),
+            date_from: if date_from().is_empty() { None } else { Some(date_from()) },
+            date_to: if date_to().is_empty() { None } else { Some(date_to()) },
+            cursor: cursor(),
+            page_size: PAGE_SIZE,
+            sort_by: Some(sort_by()),
+            sort_order: Some(sort_order()),
+        })
     });
 
     let toast = consume_toast();

--- a/src/components/notes_history/component.rs
+++ b/src/components/notes_history/component.rs
@@ -22,14 +22,22 @@ fn NoteRow(note: NoteHistory, show_kid: bool) -> Element {
     } else {
         format!("{}", note.quantity)
     };
-    let qty_bg = if note.quantity >= 0 { "#dcfce7" } else { "#fee2e2" };
-    let qty_color = if note.quantity >= 0 { "#16a34a" } else { "#dc2626" };
+    let qty_bg = if note.quantity >= 0 {
+        "#dcfce7"
+    } else {
+        "#fee2e2"
+    };
+    let qty_color = if note.quantity >= 0 {
+        "#16a34a"
+    } else {
+        "#dc2626"
+    };
 
     rsx! {
         tr {
             class: "note-row",
             style: "border-bottom: 1px solid #f3f4f6; transition: background-color 0.15s;",
-            
+
             if show_kid {
                 td {
                     style: "padding: 0.75rem 1rem; color: #9ca3af; font-size: 0.875rem; font-family: monospace;",
@@ -40,12 +48,12 @@ fn NoteRow(note: NoteHistory, show_kid: bool) -> Element {
                     "{note.kid_name}"
                 }
             }
-            
+
             td {
                 style: "padding: 0.75rem 1rem; color: #6b7280; font-size: 0.875rem;",
                 "{note.created_at}"
             }
-            
+
             td {
                 style: "padding: 0.75rem 1rem;",
                 span {
@@ -62,16 +70,16 @@ const PAGE_SIZE: u8 = 20;
 #[component]
 pub fn NotesHistoryPage() -> Element {
     let kids_resource = use_resource(list_kids);
-    
+
     // Filter state
     let mut selected_kid_id = use_signal(|| None::<u32>);
     let mut date_from = use_signal(|| String::new());
     let mut date_to = use_signal(|| String::new());
-    
+
     // Sort state
     let mut sort_by = use_signal(|| "created_at".to_string());
     let mut sort_order = use_signal(|| "desc".to_string());
-    
+
     // Pagination state
     let mut current_page = use_signal(|| 1usize);
     let mut total_pages = use_signal(|| 1usize);
@@ -84,8 +92,16 @@ pub fn NotesHistoryPage() -> Element {
     let mut notes = use_resource(move || {
         get_notes_history(NotesHistoryFilter {
             kid_id: selected_kid_id(),
-            date_from: if date_from().is_empty() { None } else { Some(date_from()) },
-            date_to: if date_to().is_empty() { None } else { Some(date_to()) },
+            date_from: if date_from().is_empty() {
+                None
+            } else {
+                Some(date_from())
+            },
+            date_to: if date_to().is_empty() {
+                None
+            } else {
+                Some(date_to())
+            },
             cursor: cursor(),
             page_size: PAGE_SIZE,
             sort_by: Some(sort_by()),
@@ -129,7 +145,11 @@ pub fn NotesHistoryPage() -> Element {
         let current_column = sort_by();
         if current_column == column {
             // Toggle order
-            let new_order = if sort_order() == "desc" { "asc" } else { "desc" };
+            let new_order = if sort_order() == "desc" {
+                "asc"
+            } else {
+                "desc"
+            };
             sort_order.set(new_order.to_string());
         } else {
             sort_by.set(column);
@@ -174,7 +194,7 @@ pub fn NotesHistoryPage() -> Element {
             div { style: "margin-bottom: 1.5rem; border-radius: 0.75rem; border: 1px solid #e5e7eb; background: white; box-shadow: 0 1px 2px rgba(0,0,0,0.05); overflow: hidden;",
                 div { style: "padding: 1.25rem;",
                     h2 { class: "text-sm font-semibold text-gray-700 mb-3", "Filters" }
-                    
+
                     div { style: "display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1rem;",
                         // Kid filter
                         div {
@@ -250,10 +270,10 @@ pub fn NotesHistoryPage() -> Element {
                 if total_count() > 0 {
                     div { style: "display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 0.75rem 1rem; border-bottom: 1px solid #e5e7eb; background: #f9fafb;",
                         button {
-                            style: if current_page() == 1 { 
-                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: not-allowed; color: #d1d5db;" 
-                            } else { 
-                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: pointer; color: #374151;" 
+                            style: if current_page() == 1 {
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: not-allowed; color: #d1d5db;"
+                            } else {
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: pointer; color: #374151;"
                             },
                             disabled: current_page() == 1,
                             onclick: move |_| {
@@ -272,10 +292,10 @@ pub fn NotesHistoryPage() -> Element {
                         }
 
                         button {
-                            style: if !has_next() { 
-                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: not-allowed; color: #d1d5db;" 
-                            } else { 
-                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: pointer; color: #374151;" 
+                            style: if !has_next() {
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: not-allowed; color: #d1d5db;"
+                            } else {
+                                "padding: 0.375rem 0.75rem; font-size: 0.875rem; border-radius: 0.5rem; border: 1px solid #e5e7eb; background: white; cursor: pointer; color: #374151;"
                             },
                             disabled: !has_next(),
                             onclick: move |_| {
@@ -302,7 +322,7 @@ pub fn NotesHistoryPage() -> Element {
                                 onclick: move |_| toggle_sort("kid_name".to_string()),
                                 span { "Kid " }
                                 if sort_by() == "kid_name" {
-                                    span { 
+                                    span {
                                         style: "margin-left: 0.25rem;",
                                         if sort_order() == "asc" { "↑" } else { "↓" }
                                     }
@@ -313,7 +333,7 @@ pub fn NotesHistoryPage() -> Element {
                                 onclick: move |_| toggle_sort("created_at".to_string()),
                                 span { "Date " }
                                 if sort_by() == "created_at" {
-                                    span { 
+                                    span {
                                         style: "margin-left: 0.25rem;",
                                         if sort_order() == "asc" { "↑" } else { "↓" }
                                     }

--- a/src/components/notes_history/component.rs
+++ b/src/components/notes_history/component.rs
@@ -32,6 +32,10 @@ fn NoteRow(note: NoteHistory, show_kid: bool) -> Element {
             
             if show_kid {
                 td {
+                    style: "padding: 0.75rem 1rem; color: #9ca3af; font-size: 0.875rem; font-family: monospace;",
+                    "id: {note.kid_id}"
+                }
+                td {
                     style: "padding: 0.75rem 1rem; font-weight: 500; color: #374151;",
                     "{note.kid_name}"
                 }
@@ -57,7 +61,7 @@ const PAGE_SIZE: u8 = 20;
 
 #[component]
 pub fn NotesHistoryPage() -> Element {
-    let mut kids_resource = use_resource(list_kids);
+    let kids_resource = use_resource(list_kids);
     
     // Filter state
     let mut selected_kid_id = use_signal(|| None::<u32>);
@@ -184,13 +188,13 @@ pub fn NotesHistoryPage() -> Element {
                                             selected_kid_id.set(if val.is_empty() { None } else { val.parse().ok() });
                                         },
                                         option { value: "", "All Kids" }
-                                        for kid in kids.iter() {
-                                            option {
-                                                value: "{kid.id}",
-                                                selected: selected_kid_id() == Some(kid.id),
-                                                "{kid.name}"
-                                            }
-                                        }
+                                         for kid in kids.iter() {
+                                             option {
+                                                 value: "{kid.id}",
+                                                 selected: selected_kid_id() == Some(kid.id),
+                                                 "id: {kid.id} - {kid.name}"
+                                             }
+                                         }
                                     }
                                 },
                                 _ => rsx! {
@@ -290,6 +294,10 @@ pub fn NotesHistoryPage() -> Element {
                         style: "background: #f9fafb;",
                         tr {
                             th {
+                                style: "padding: 0.75rem 1rem; text-align: left; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;",
+                                "Id"
+                            }
+                            th {
                                 style: "padding: 0.75rem 1rem; text-align: left; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em; cursor: pointer; user-select: none;",
                                 onclick: move |_| toggle_sort("kid_name".to_string()),
                                 span { "Kid " }
@@ -322,7 +330,7 @@ pub fn NotesHistoryPage() -> Element {
                             None => rsx! {
                                 tr {
                                     td {
-                                        colspan: 3,
+                                        colspan: 4,
                                         style: "padding: 2rem; text-align: center; color: #9ca3af;",
                                         "Loading..."
                                     }
@@ -331,7 +339,7 @@ pub fn NotesHistoryPage() -> Element {
                             Some(Ok(response)) if response.notes.is_empty() => rsx! {
                                 tr {
                                     td {
-                                        colspan: 3,
+                                        colspan: 4,
                                         style: "padding: 3rem; text-align: center;",
                                         div {
                                             style: "color: #9ca3af;",
@@ -352,7 +360,7 @@ pub fn NotesHistoryPage() -> Element {
                             Some(Err(_)) => rsx! {
                                 tr {
                                     td {
-                                        colspan: 3,
+                                        colspan: 4,
                                         style: "padding: 2rem; text-align: center; color: #ef4444;",
                                         "Failed to load notes"
                                     }

--- a/src/components/notes_history/component.rs
+++ b/src/components/notes_history/component.rs
@@ -1,6 +1,6 @@
 use crate::backend::kids::list_kids;
 use crate::backend::notes_history_query::NotesHistoryFilter;
-use crate::models::{KidSummary, NoteHistory};
+use crate::models::NoteHistory;
 use crate::Route;
 use dioxus::prelude::*;
 use dioxus_primitives::toast::{consume_toast, ToastOptions};
@@ -77,7 +77,7 @@ pub fn NotesHistoryPage() -> Element {
     let mut cursor_stack = use_signal(|| vec![None::<String>]);
 
     // The notes resource - reactive to all filters and cursor
-    let notes = use_resource(move || {
+    let mut notes = use_resource(move || {
         get_notes_history(NotesHistoryFilter {
             kid_id: selected_kid_id(),
             date_from: if date_from().is_empty() { None } else { Some(date_from()) },
@@ -121,7 +121,7 @@ pub fn NotesHistoryPage() -> Element {
         notes.restart();
     };
 
-    let toggle_sort = move |column: String| {
+    let mut toggle_sort = move |column: String| {
         let current_column = sort_by();
         if current_column == column {
             // Toggle order

--- a/src/components/notes_history/mod.rs
+++ b/src/components/notes_history/mod.rs
@@ -1,0 +1,2 @@
+mod component;
+pub use component::NotesHistoryPage;

--- a/src/components/settings/component.rs
+++ b/src/components/settings/component.rs
@@ -401,7 +401,10 @@ pub fn SettingsPage() -> Element {
                             h2 { class: "text-lg font-semibold text-gray-900", "History" }
                             p { class: "text-sm text-gray-400", style: "margin-top: 2px;", "View past notes and activity." }
                         }
-                        Button { variant: ButtonVariant::Secondary, "View History" }
+                        Link {
+                            to: Route::NotesHistoryView,
+                            Button { variant: ButtonVariant::Secondary, "View History" }
+                        }
                     }
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ mod utils;
 
 #[cfg(feature = "server")]
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
 
 #[cfg(feature = "server")]
 use axum::extract::ConnectInfo;
@@ -19,6 +18,7 @@ use dioxus::prelude::*;
 
 use components::about::AboutPage;
 use components::kid_history::KidHistoryPage;
+use components::notes_history::NotesHistoryPage;
 use components::settings::SettingsPage;
 use components::toast::ToastProvider;
 use notica_component::NoticaApp;
@@ -80,6 +80,8 @@ pub enum Route {
     AboutView,
     #[route("/kid/:id")]
     KidHistory { id: u32 },
+    #[route("/history")]
+    NotesHistoryView,
 }
 
 #[component]
@@ -115,6 +117,17 @@ fn KidHistory(id: u32) -> Element {
         div { style: "min-height: 100vh; background-color: #f3f4f6;",
             div { style: "max-width: 520px; margin: 0 auto; padding: 2rem 1rem;",
                 KidHistoryPage { kid_id: id }
+            }
+        }
+    }
+}
+
+#[component]
+fn NotesHistoryView() -> Element {
+    rsx! {
+        div { style: "min-height: 100vh; background-color: #f3f4f6;",
+            div { style: "max-width: 720px; margin: 0 auto; padding: 2rem 1rem;",
+                NotesHistoryPage {}
             }
         }
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -131,3 +131,21 @@ pub struct NoteDetails {
     pub quantity: i32,
     pub created_at: NaiveDateTime,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NoteHistory {
+    pub id: i64,
+    pub kid_id: u32,
+    pub kid_name: String,
+    pub quantity: i32,
+    pub created_at: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NoteHistoryResponse {
+    pub notes: Vec<NoteHistory>,
+    pub cursor: Option<String>,
+    pub total_count: u32,
+    pub current_page: u32,
+    pub total_pages: u32,
+}


### PR DESCRIPTION
## Summary

This PR adds a Notes History page accessible from the Settings component.

## Changes

### Backend
- New `notes_history_query.rs` module following the existing modular pattern
- Cursor-based pagination (consistent with `history_query.rs`)
- JOIN with kids table to display kid names
- Filtering by kid_id and date range (from/to)
- Sorting by kid name or created_at

### Frontend
- New `NotesHistoryPage` component with:
  - Table styled to match the project (white cards, rounded corners)
  - Kid filter dropdown
  - Date range filters (from/to)
  - Sortable columns (kid name, created_at)
  - Cursor-based pagination with prev/next
- Route `/history` registered in the router
- "View History" button in Settings now links to `/history`

## Commits

1. `Add NoteHistory and NoteHistoryResponse models` - Data models for notes history
2. `Add notes_history_query backend module with cursor pagination` - Backend query logic
3. `Add NotesHistoryPage component with table, filters, and pagination` - Frontend component
4. `Add NotesHistoryView route and link from settings` - Route and navigation

## Testing

Start the app with `dx serve --platform web` and navigate to Settings → View History

Closes the issue for implementing the Notes History page.